### PR TITLE
Fix RTL9210B_CG_UGREEN configuration

### DIFF
--- a/configure/RTL9210B_CG_UGREEN.cfg
+++ b/configure/RTL9210B_CG_UGREEN.cfg
@@ -6,8 +6,6 @@ PID = 0x9210
 MANUFACTURE = "Ugreen"
 PRODUCT = "Ugreen Storage Device"
 SERIAL = "0129380003DD"
-SCSI_PRODUCT = "n/a"
-SCSI_VENDOR = "n/a"
 
 DISK_HOTPLUG = 0x1
 LED = 0x1


### PR DESCRIPTION
## Problem
After flashing firmware with the original config, Windows detected the drive enclosure as "n/a n/a" instead of the proper drive name. The dump shows dirty values with padding for `SCSI_PRODUCT` and `SCSI_VENDOR` parameters.

## Dumps comparison
**After flashing firmware with the original config:**
```
**************************************************************
Device : [Port6] : n/a n/a #0
**************************************************************
SCSI_PRODUCT : "n/a             "
SCSI_VENDOR : "n/a     "
```

**After flashing firmware with the fixed config:**
```
**************************************************************
Device : [Port6] : KINGSTON  SKC3000D2048G #0
**************************************************************
SCSI_PRODUCT : "n/a"
SCSI_VENDOR : "n/a"
```

## Result
- Config dump now shows clean values: `SCSI_PRODUCT : "n/a"` and `SCSI_VENDOR : "n/a"`
- Windows properly detects the drive (e.g., `KINGSTON SKC3000D2048G` instead of `n/a n/a`)