### PR TITLE
Add a new script for converting dump files to configuration files

### DIFF
--- a/tools/dump2cfg.py
+++ b/tools/dump2cfg.py
@@ -1,0 +1,30 @@
+#!/usr/bin/python3
+
+import sys
+import re
+
+if len(sys.argv) < 2:
+    print('Usage:', sys.argv[0], '<dump file>')
+    exit(1)
+
+kre = re.compile(r'^[A-Z_]+$')
+fin = open(sys.argv[1], 'r')
+fout = None
+
+for line in fin:
+    fields = line.split(':')
+    if len(fields) < 2:
+        continue
+
+    key = fields[0].strip()
+    val = fields[1].strip()
+
+    if key == 'Device':
+        if fout:
+            fout.close()
+        fout = open(val.strip('[]') + '.cfg', 'w')
+        fout.write('; ' + val + ' : ' + fields[2].strip() + '\r\n')
+    elif kre.match(key) and val != 'n/a':
+        fout.write(key + ' = ' + val + '\r\n')
+
+fout.close()


### PR DESCRIPTION
This script will read the dump file created by the firmware updater and will write a separate configuration file for each connected device found in the dump file to the current directory. It's intended to automate most of the process described in the main README for creating custom configuration files. I thought this might be useful for future users as I found it tedious to make sure each of my enclosures was using a suitable configuration. Please note that this script only supports dump files written by the firmware updater. If any custom modifications were made, compatibility is not guaranteed.